### PR TITLE
修复wsclient传输数据类型和wsservice数据类型不一致。

### DIFF
--- a/network/ws_server.go
+++ b/network/ws_server.go
@@ -2,12 +2,13 @@ package network
 
 import (
 	"crypto/tls"
-	"github.com/duanhf2012/origin/log"
-	"github.com/gorilla/websocket"
 	"net"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/duanhf2012/origin/log"
+	"github.com/gorilla/websocket"
 )
 
 type WSServer struct {
@@ -139,6 +140,7 @@ func (server *WSServer) Start() {
 		maxMsgLen:       server.MaxMsgLen,
 		newAgent:        server.NewAgent,
 		conns:           make(WebsocketConnSet),
+		messageType:     server.messageType,
 		upgrader: websocket.Upgrader{
 			HandshakeTimeout: server.HTTPTimeout,
 			CheckOrigin:      func(_ *http.Request) bool { return true },


### PR DESCRIPTION
调整 通过&WSService.SetMessageType 方法设置websocket service 的messagetype  wsclient binaryType 不能同时设置